### PR TITLE
Scoping profile view model to Profile screen

### DIFF
--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/navigation/AppNavigation.kt
@@ -157,7 +157,8 @@ private fun NavGraphBuilder.employeesGraph(
 		}
 		composable(AppScreen.Profile.route) {
 			Profile(
-				bottomSheetViewModel = bottomSheetViewModel
+				bottomSheetViewModel = bottomSheetViewModel,
+				profileViewModel = it.hiltViewModel()
 			)
 		}
 	}

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/screens/profile/Profile.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/screens/profile/Profile.kt
@@ -21,7 +21,7 @@ import ru.rtuitlab.itlab.presentation.utils.singletonViewModel
 @ExperimentalMaterialApi
 @Composable
 fun Profile(
-	profileViewModel: ProfileViewModel = singletonViewModel(),
+	profileViewModel: ProfileViewModel,
 	bottomSheetViewModel: BottomSheetViewModel
 ) {
 	val userCredentialsResource by profileViewModel.userCredentialsFlow.collectAsState()


### PR DESCRIPTION
Есть баг на экране профиля, когда отображается старый профиль после перелогина и без перезапуска приложения. Этот ПР фиксит отображение. Баг остаётся в настройках профиля, быстрого решения не нашёл.