### PR TITLE
Edge-to-edge дизайн и нормальная работа с поиском

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
         <activity
             android:name=".presentation.MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:label="@string/app_name"
             android:theme="@style/Theme.App.Starting">
             <intent-filter>

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/navigation/NavigationControl.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/navigation/NavigationControl.kt
@@ -35,6 +35,7 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import ru.rtuitlab.itlab.presentation.screens.events.EventsViewModel
 import ru.rtuitlab.itlab.presentation.ui.components.top_app_bars.AppBarViewModel
 import ru.rtuitlab.itlab.presentation.ui.components.top_app_bars.AppTabsViewModel
+import ru.rtuitlab.itlab.presentation.ui.insets.horizontalNavigationBarsPadding
 import ru.rtuitlab.itlab.presentation.utils.AppTab
 import ru.rtuitlab.itlab.presentation.utils.singletonViewModel
 
@@ -81,7 +82,8 @@ fun NavigationControl(
     // If total amount of tabs is odd, we want the leftmost column to hold the least amount of children
     Box(
         modifier = Modifier
-            .fillMaxSize(),
+            .fillMaxSize()
+            .horizontalNavigationBarsPadding(),
         contentAlignment = Alignment.BottomEnd
     ) {
         // Scrim for navigation

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/screens/employees/Employee.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/screens/employees/Employee.kt
@@ -36,6 +36,7 @@ import ru.rtuitlab.itlab.presentation.ui.components.IconizedRow
 import ru.rtuitlab.itlab.presentation.ui.components.backdrop.BackdropScaffold
 import ru.rtuitlab.itlab.presentation.ui.components.backdrop.BackdropValue
 import ru.rtuitlab.itlab.presentation.ui.components.backdrop.rememberBackdropScaffoldState
+import java.lang.Integer.min
 
 @ExperimentalPagerApi
 @ExperimentalMaterialApi
@@ -60,13 +61,18 @@ fun Employee(
             user?.let { user ->
                 SubcomposeAsyncImage(
                     modifier = Modifier.offset {
-                        IntOffset(0, (backdropScaffoldState.offset.value.toInt() - screenWidth + 16.dp.toPx().toInt()) / 2)
-                    },
+                        IntOffset(
+                            0,
+                            (backdropScaffoldState.offset.value.toInt() - min(screenWidth, screenHeightDp.toPx().toInt()) + 16.dp.toPx().toInt()) / 2
+                        )
+                    }
+                        .fillMaxWidth(),
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(user.getGravatarWithSize(screenWidth))
                         .crossfade(true)
                         .build(),
                     contentDescription = stringResource(R.string.gravatar),
+                    contentScale = ContentScale.FillWidth,
                     loading = {
                         AsyncImage(
                             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/screens/reports/NewReport.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/screens/reports/NewReport.kt
@@ -36,6 +36,7 @@ import ru.rtuitlab.itlab.presentation.ui.components.*
 import ru.rtuitlab.itlab.presentation.ui.components.markdown.MarkdownTextArea
 import ru.rtuitlab.itlab.presentation.ui.components.markdown.MdAction
 import ru.rtuitlab.itlab.presentation.ui.components.markdown.MdAction.Companion.asTextActionsOn
+import ru.rtuitlab.itlab.presentation.ui.components.modifier.fabAwarePadding
 import ru.rtuitlab.itlab.presentation.ui.components.shared_elements.FadeMode
 import ru.rtuitlab.itlab.presentation.ui.components.shared_elements.SharedElement
 import ru.rtuitlab.itlab.presentation.ui.components.shared_elements.utils.ProgressThresholds
@@ -125,7 +126,7 @@ fun NewReport(
                 color = MaterialTheme.colorScheme.background
             ) {
                 Column(
-                    modifier = Modifier.padding(16.dp),
+                    modifier = Modifier.fabAwarePadding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Text(

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/ITLabApp.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/ITLabApp.kt
@@ -49,6 +49,7 @@ import ru.rtuitlab.itlab.presentation.ui.components.shared_elements.LocalSharedE
 import ru.rtuitlab.itlab.presentation.ui.components.top_app_bars.AppBarViewModel
 import ru.rtuitlab.itlab.presentation.ui.components.top_app_bars.BasicTopAppBar
 import ru.rtuitlab.itlab.presentation.ui.components.top_app_bars.CenterAlignedTopAppBar
+import ru.rtuitlab.itlab.presentation.ui.insets.horizontalNavigationBarsPadding
 import ru.rtuitlab.itlab.presentation.utils.AppScreen
 import kotlin.math.roundToInt
 
@@ -99,7 +100,9 @@ fun ITLabApp(
 
     val mainFloatingActionButton: @Composable () -> Unit = {
         FloatingActionButton(
-            modifier = Modifier.offset { mainFabOffset },
+            modifier = Modifier
+                .offset { mainFabOffset }
+                .navigationBarsPadding(),
             onClick = { isNavigationOpen = true },
             containerColor = ITLabBottomBarDefaults.mainFloatingActionButtonContainerColor,
             elevation = ITLabBottomBarDefaults.floatingActionButtonsElevation
@@ -130,6 +133,7 @@ fun ITLabApp(
                     modifier = Modifier
                         .background(MaterialTheme.colorScheme.surface)
                         .statusBarsPadding()
+                        .horizontalNavigationBarsPadding()
                         .animateContentSize()
                 ) {
                     when (currentScreen) {
@@ -183,6 +187,7 @@ fun ITLabApp(
                         bottom = if (currentScreen.hasBottomBar) it.calculateBottomPadding() else 0.dp,
                         top = it.calculateTopPadding()
                     )
+                        .horizontalNavigationBarsPadding()
                 ) {
                     AppNavigation(navController)
                 }

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/ITLabApp.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/ITLabApp.kt
@@ -6,6 +6,7 @@ package ru.rtuitlab.itlab.presentation.ui
 import androidx.compose.animation.*
 import androidx.compose.animation.core.ExperimentalTransitionApi
 import androidx.compose.animation.core.animateIntOffsetAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
@@ -123,9 +124,13 @@ fun ITLabApp(
         scrimColor = MaterialTheme.colorScheme.scrim.copy(.25f)
     ) {
         Scaffold(
+            modifier = Modifier.imePadding(),
             topBar = {
                 Box(
-                    modifier = Modifier.animateContentSize()
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.surface)
+                        .statusBarsPadding()
+                        .animateContentSize()
                 ) {
                     when (currentScreen) {
                         AppScreen.Events -> EventsTopBar()

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/components/SearchBar.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/components/SearchBar.kt
@@ -147,7 +147,8 @@ private fun SearchBarContent(
 				disabledBorderColor = Color.Transparent,
 				errorBorderColor = Color.Transparent,
 				focusedBorderColor = Color.Transparent
-			)
+			),
+			singleLine = true
 		)
 	}
 

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/components/bottom_app_bar/BottomAppBar.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/components/bottom_app_bar/BottomAppBar.kt
@@ -39,7 +39,7 @@ fun BottomAppBar(
     contentColor: Color = contentColorFor(containerColor),
     tonalElevation: Dp = BottomAppBarDefaults.ContainerElevation,
     contentPadding: PaddingValues = BottomAppBarDefaults.ContentPadding,
-    windowInsets: WindowInsets = BottomAppBarDefaults.windowInsets,
+    windowInsets: WindowInsets = WindowInsets.navigationBars,
     isSearchQueryApplied: Boolean = false,
     searchBar: @Composable ((onDismissRequest: () -> Unit) -> Unit)? = null
 ) {

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/components/bottom_sheet/BottomSheet.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/components/bottom_sheet/BottomSheet.kt
@@ -61,6 +61,7 @@ fun BottomSheet(
 					start = 15.dp,
 					end = 15.dp
 				)
+				.navigationBarsPadding()
 				.fillMaxWidth(),
 			horizontalAlignment = Alignment.CenterHorizontally
 		) {

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/insets/InsetsPaddingModifier.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/insets/InsetsPaddingModifier.kt
@@ -1,0 +1,10 @@
+package ru.rtuitlab.itlab.presentation.ui.insets
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+
+fun Modifier.horizontalNavigationBarsPadding() =
+    composed {
+        windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal))
+    }

--- a/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/theme/Theme.kt
+++ b/app/src/main/java/ru/rtuitlab/itlab/presentation/ui/theme/Theme.kt
@@ -107,12 +107,17 @@ fun ITLabTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable 
 		shapes = ru.rtuitlab.itlab.presentation.ui.theme.md3.shapes
 	) {
 		val systemUiController = rememberSystemUiController()
-		val colorScheme = androidx.compose.material3.MaterialTheme.colorScheme
 		SideEffect {
-			systemUiController.setStatusBarColor(
-				color = colorScheme.primaryContainer,
-				darkIcons = !darkTheme
-			)
+			systemUiController.apply {
+				setStatusBarColor(
+					color = Color.Transparent,
+					darkIcons = !darkTheme
+				)
+				setNavigationBarColor(
+					color = Color.Transparent,
+					darkIcons = !darkTheme
+				)
+			}
 		}
 
 		MaterialTheme(


### PR DESCRIPTION
В этой ветке дичайшим костылём пофикшен [известный баг](https://issuetracker.google.com/issues/264601542) M3-компонента `Scaffold`, который не фиксится четвёртый месяц и не позволяет реализовать [edge to edge дизайн](https://developer.android.com/develop/ui/views/layout/edge-to-edge) и удобную [работу](https://developer.android.com/develop/ui/views/layout/sw-keyboard#synchronize-animation) с нижним поиском в приложении.  
Как только этот баг наконец пофиксят, все изменения первого коммита этой ветки будет необходимо снести воимя всего святого.

Было:  
![было](https://user-images.githubusercontent.com/44675043/232310104-06f1eac0-f0b7-401b-9464-a89e165b0888.gif)


Стало:  
![стало](https://user-images.githubusercontent.com/44675043/232310111-42196643-a500-4838-926a-65703da8659e.gif)

